### PR TITLE
use LDADD/LIBADD instead of LDFLAGS for the libraries

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,22 +14,29 @@ libftdi_bitbang_la_LDFLAGS = @libftdi1_LIBS@
 libftdi_bitbang_la_CFLAGS = @libftdi1_CFLAGS@
 
 libftdi_hd44780_la_SOURCES = ftdi-hd44780.c
-libftdi_hd44780_la_LDFLAGS = -lftdi-bitbang @libftdi1_LIBS@
+libftdi_hd44780_la_LIBADD = libftdi-bitbang.la
+libftdi_hd44780_la_LDFLAGS = @libftdi1_LIBS@
 libftdi_hd44780_la_CFLAGS = @libftdi1_CFLAGS@
 
 libftdi_spi_la_SOURCES = ftdi-spi.c
-libftdi_spi_la_LDFLAGS = -lftdi-bitbang @libftdi1_LIBS@
+libftdi_spi_la_LIBADD = libftdi-bitbang.la
+libftdi_spi_la_LDFLAGS = @libftdi1_LIBS@
 libftdi_spi_la_CFLAGS = @libftdi1_CFLAGS@
 
-ftdi_bitbang_LDFLAGS = -lftdi-bitbang @libftdi1_LIBS@
+ftdi_bitbang_LDADD = libftdi-bitbang.la
+ftdi_bitbang_LDFLAGS = @libftdi1_LIBS@
 ftdi_bitbang_CFLAGS = @libftdi1_CFLAGS@
-ftdi_hd44780_LDFLAGS = -lftdi-bitbang -lftdi-hd44780 @libftdi1_LIBS@
+ftdi_hd44780_LDADD = libftdi-bitbang.la libftdi-hd44780.la
+ftdi_hd44780_LDFLAGS = @libftdi1_LIBS@
 ftdi_hd44780_CFLAGS = @libftdi1_CFLAGS@
-ftdi_control_LDFLAGS = -lftdi-bitbang @libftdi1_LIBS@
+ftdi_control_LDADD = libftdi-bitbang.la
+ftdi_control_LDFLAGS = @libftdi1_LIBS@
 ftdi_control_CFLAGS = @libftdi1_CFLAGS@
-ftdi_spi_LDFLAGS = -lftdi-bitbang -lftdi-spi @libftdi1_LIBS@
+ftdi_spi_LDADD = libftdi-bitbang.la libftdi-spi.la
+ftdi_spi_LDFLAGS = @libftdi1_LIBS@
 ftdi_spi_CFLAGS = @libftdi1_CFLAGS@
-ftdi_simple_capture_LDFLAGS = -lftdi-bitbang -lpthread @libftdi1_LIBS@
+ftdi_simple_capture_LDADD = libftdi-bitbang.la
+ftdi_simple_capture_LDFLAGS = -lpthread @libftdi1_LIBS@
 ftdi_simple_capture_CFLAGS = @libftdi1_CFLAGS@
 
 include_HEADERS = ftdi-bitbang.h ftdi-hd44780.h ftdi-spi.h


### PR DESCRIPTION
Without this linking fails in OE since the non installed libraries are
in ./libs and linking fails with "cannot find -lftdi-bitbang". Switching
to LDADD fixes this since ./.libs/libftdi-bitbang.so is then used.