### PR TITLE
Modify bitbang library to use bitbang mode for FT4232H compatibility

### DIFF
--- a/src/cmd-bitbang.c
+++ b/src/cmd-bitbang.c
@@ -149,14 +149,6 @@ int main(int argc, char *argv[])
 			p_exit(EXIT_FAILURE);
 		}
 		printf("%d\n", pins & (1 << read_pin) ? 1 : 0);
-	} else if (read_pin > 7 && read_pin < 16) {
-		int pins = ftdi_bitbang_read_high(device);
-		if (pins < 0) {
-			fprintf(stderr, "failed reading pin state\n");
-			p_exit(EXIT_FAILURE);
-		}
-		read_pin -= 8;
-		printf("%d\n", pins & (1 << read_pin) ? 1 : 0);
 	}
 
 

--- a/src/ftdi-bitbang.h
+++ b/src/ftdi-bitbang.h
@@ -15,9 +15,6 @@ struct ftdi_bitbang_state {
 	uint8_t l_value;
 	uint8_t l_changed;
 	uint8_t l_io;
-	uint8_t h_value;
-	uint8_t h_changed;
-	uint8_t h_io;
 };
 struct ftdi_bitbang_context {
 	struct ftdi_context *ftdi;
@@ -32,7 +29,6 @@ int ftdi_bitbang_set_io(struct ftdi_bitbang_context *dev, int bit, int io);
 
 int ftdi_bitbang_write(struct ftdi_bitbang_context *dev);
 int ftdi_bitbang_read_low(struct ftdi_bitbang_context *dev);
-int ftdi_bitbang_read_high(struct ftdi_bitbang_context *dev);
 int ftdi_bitbang_read(struct ftdi_bitbang_context *dev);
 int ftdi_bitbang_read_pin(struct ftdi_bitbang_context *dev, uint8_t pin);
 


### PR DESCRIPTION
This allows using all four ports on an FT4232H, which only has two MPSSE engines. However, it has four channels, and all four channels can be used in "bitbang" mode (distinct from MPSSE mode).  These channels only break out the bottom 8 bits onto pins.

So, this PR changes the meaning of "interface" to mean the A, B, C, or D port (so an FT4232 has interfaces 1-4), and uses bitbang mode to command them.  This lets me use interface 4 on my FT4232 on my custom hardware, which has GPIO mapped to channel 4 and UARTs on channels 1 thru 3.

This change as written would substantially break existing functionality for other chips that only have two channels anyway.  However I wanted to open a dialogue about what can be done to support the FT4232, because this tool is really useful otherwise.